### PR TITLE
Mejoras en hispachan-scraping.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Web-Scraping
-
----
+# Web-Scraping (Node.js)
 
 ## Descripción
 
@@ -25,3 +23,12 @@ No me hago responsable por el mal uso o daños a otros realizados por esta herra
 
 ## Bugs conocidos:
 No descarga los videos, los selecciona pero aun no los maneja
+
+---
+# hispachan-scraping.py
+## Descripción
+Versión simplificada del scrapper hecha en Python.
+## Uso
+`python hispachan-scraping.py enlace_hilo`
+## Bugs conocidos
+Ninguno por ahora, pero faltaría afinar el manejo de excepciones y hacer mas pruebas con la expresión regular que detecta enlaces y nombres reales de los archivos.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ No me hago responsable por el mal uso o daños a otros realizados por esta herra
 `Ejemplo: sudo ./index.js --tablon=di --hilo=50859`  
 
 #### Windows
-`Para usar en windows debes modificar el archivo package.json en la linea 8 con el tablon y el hilo que quieres descargar, luego ejectuar npm run win`
+Para usar en windows debes modificar el archivo package.json en la linea 8 con el tablón y el hilo que quieres descargar, luego ejecutar `npm run win`
 
 ## Bugs conocidos:
 No descarga los videos, los selecciona pero aun no los maneja

--- a/hispachan-scraping.py
+++ b/hispachan-scraping.py
@@ -1,17 +1,23 @@
+# -*- coding: utf-8 -*-
 import requests, re, sys, os
 
 enlace = re.compile("https?://(www\.)?hispachan\.org/([a-z]+)/res/([0-9]+)\.html")
 x, tablon, idpost = enlace.match(sys.argv[1]).groups()
-adjuntos = re.compile('https://www\.hispachan\.org/%s/src/[0-9]+\.[^\'"]+' % tablon)
+adjuntos = re.compile('<span class="file(?:namereply|size)">[\r\n]+<a[\s\r\n]+target="_blank"[\s\r\n]+href="([^"]+)"(?:[\s\S]*?)<span class="nombrefile"(?:>, ([^<]+)| title="([^"]+))')
 peticion = requests.get("https://www.hispachan.org/%s/res/%s.html" % (tablon, idpost))
 # Si el hilo aun existe extrae los archivos
 if peticion.status_code == 200:
-    os.makedirs(os.path.join(tablon, idpost))
-    for archivo in list(set(adjuntos.findall(peticion.content))):
-        print "Descargando " + archivo
+    try: os.makedirs(os.path.join(tablon, idpost))
+    except OSError, e:
+        if e.errno == os.errno.EEXIST:
+            respuesta = raw_input("La carpeta donde se descargaran los archivos ya existe. ¿Desea sobreescribir los archivos? [s/n]: ")
+            if respuesta in ["n", "N"]: exit(17)
+    for archivo, nombre1, nombre2 in adjuntos.findall(peticion.content):
+        nombre = (nombre1 if nombre2 == "" else nombre2)
+        print("Descargando %s (%s)" % (archivo, nombre))
         descarga = requests.get(archivo)
         # El archivo basicamente se guarda en tablon/post/nombre
-        salida = open(os.path.join(tablon, idpost, archivo.split("/")[-1]), "wb")
+        salida = open(os.path.join(tablon, idpost, nombre), "wb")
         salida.write(descarga.content)
         salida.close()
 else: print("El hilo no existe")

--- a/hispachan-scraping.py
+++ b/hispachan-scraping.py
@@ -17,7 +17,12 @@ if peticion.status_code == 200:
         print("Descargando %s (%s)" % (archivo, nombre))
         descarga = requests.get(archivo)
         # El archivo basicamente se guarda en tablon/post/nombre
-        salida = open(os.path.join(tablon, idpost, nombre), "wb")
+        # Al parecer las imagenes dentro de un spoiler no contienen nombre propio
+        # por lo que se usa el timestamp en su lugar
+        if nombre == "Spoiler Picture.jpg":
+            salida = open(os.path.join(tablon, idpost, archivo.split("/")[-1]), "wb")
+        else:
+            salida = open(os.path.join(tablon, idpost, nombre), "wb")
         salida.write(descarga.content)
         salida.close()
 else: print("El hilo no existe")


### PR DESCRIPTION
Mejore la detección de los archivos con una expresión regular mas avanzada; ahora se pueden bajar con su nombre real e incluso pdfs que no usan el típico formato de nombres que las imágenes y vídeos.
También agregue un manejo básico de excepciones cuando el programa se encuentra con una carpeta que ya existe previamente, pero faltaría comprobar cuando se bajan los archivos de un hilo donde haya dos o mas archivos con nombre repetido (algo así como lo que pasa con las imágenes de spoilers).
Otras cosas que agregue fueron la definición de la codificación en la cabecera y un ajuste menor en el print.
Por ultimo me tome la libertad de agregar información sobre el script en el readme junto con algunas correcciones.